### PR TITLE
Changed way that the user icon is retrieved

### DIFF
--- a/src/transcripts/transcript.ts
+++ b/src/transcripts/transcript.ts
@@ -79,7 +79,7 @@ export const generateTranscript = (
                                         let img = document.createElement("img");
                                         img.setAttribute(
                                             "src",
-                                            msg.author.avatar
+                                            'https://cdn.discordapp.com/avatars/'+msg.author.id+"/"+msg.author.avatar+".png"
                                         );
                                         img.className = "avatar";
                                         avatarDiv.appendChild(img);


### PR DESCRIPTION
Changed way that the user icon is retrieved so that it will stop it from looking like this: 
[before](https://gyazo.com/4e97694aebb268b0cb19625a81f1c3e0) 
where the images aren't got and will instead look like this: 
[Fixed](https://gyazo.com/202051eb40ea94d4eb2404b3d47ae538)